### PR TITLE
Add rule ECS0007

### DIFF
--- a/docs/rules/ECS0007.md
+++ b/docs/rules/ECS0007.md
@@ -1,0 +1,76 @@
+# ECS0007: Express Callbacks with Delegates
+
+> This rule is described in detail in [Effective C#: 50 Specific Ways to Improve your C#](https://www.oreilly.com/library/view/effective-c-50/9780134579290/).
+
+The problem addressed by this rule is the use of methods that should involve callback mechanisms without employing delegates for this purpose. Specifically, methods are being invoked directly without the use of delegate types such as `Predicate<T>`, `Action<T>`, or `Func<T>`, which are designed to handle callbacks in a type-safe and consistent manner.
+
+Why is it a Problem?
+
+1. Readability and Maintainability: Direct method invocations for callbacks can make the code less readable and harder to maintain. It becomes difficult to track what the callback logic is and how it flows through the system.
+2. Separation of Concerns: Without delegates, the separation between the logic that triggers the callback and the callback implementation itself is blurred, leading to tighter coupling between components.
+3. Type Safety: Delegates provide type safety, ensuring that the callback methods match the expected signature. This prevents runtime errors and makes the code more robust.
+4. Flexibility and Reusability: Using delegates allows for more flexible and reusable code. Delegates can represent single or multicast methods, providing a versatile mechanism for handling various callback scenarios.
+5. Asynchronous Operations: Delegates are essential for handling asynchronous operations and deferred execution, which are common in modern C# applications. Without delegates, managing asynchronous callbacks becomes cumbersome and error-prone.
+
+## Cause
+
+The analyzer flags method invocations where delegate parameters are not utilized for callbacks, instead relying on other mechanisms. This can lead to less readable and maintainable code.
+
+## Rule Description
+
+Using delegates for callbacks provides a type-safe, clear, and consistent way to handle asynchronous or deferred execution. It allows for better separation of concerns and reduces tight coupling between components. Delegates can represent single or multicast methods, making them flexible for various callback scenarios.
+
+## How to Fix Violations
+
+To fix violations, refactor the code to use delegates for callbacks. This usually involves defining a delegate type (such as `Action<T>`, `Func<T>`, or `Predicate<T>`) and using it in method signatures and invocations.
+
+## When to Suppress Warnings
+
+Suppress warnings if using delegates is not feasible due to specific architectural or performance considerations. Ensure that alternative methods are well-documented and justified.
+
+## Example of a Violation
+
+### Description
+
+The following example shows a violation where methods are called directly without using a delegate for callbacks.
+
+### Code
+
+```csharp
+public class MyClass
+{
+    public void Test()
+    {
+        List<int> numbers = Enumerable.Range(1, 200).ToList();
+        var oddNumbers = numbers.Find(n => n % 2 == 1);
+        var test = numbers.TrueForAll(n => n < 50);
+
+        numbers.RemoveAll(n => n % 2 == 0);
+
+        numbers.ForEach(item => Console.WriteLine(item));
+    }
+}
+
+## Example of How to Fix
+
+### Description
+
+Refactor the code to use delegates for callbacks, such as `Predicate<int>` for `Find`, `TrueForAll`, and `RemoveAll`, and `Action<int>` for `ForEach`.
+
+### Code
+
+```csharp
+public class MyClass
+{
+    public void Test()
+    {
+        List<int> numbers = Enumerable.Range(1, 200).ToList();
+        var oddNumbers = numbers.Find(new Predicate<int>(n => n % 2 == 1));
+        var test = numbers.TrueForAll(new Predicate<int>(n => n < 50));
+
+        numbers.RemoveAll(new Predicate<int>(n => n % 2 == 0));
+
+        numbers.ForEach(new Action<int>(item => Console.WriteLine(item)));
+    }
+}
+```

--- a/src/EffectiveCSharp.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/EffectiveCSharp.Analyzers/AnalyzerReleases.Unshipped.md
@@ -8,5 +8,6 @@ ECS0001 | Style | Info | PreferImplicitlyTypedLocalVariablesAnalyzer, [Documenta
 ECS0002 | Maintainability | Info | PreferReadonlyOverConstAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/10c2d53afd688efe5a59097f76cb4edf33f6a474/docs/ECS0002.md)
 ECS0004 | Style | Info | ReplaceStringFormatAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers5da647e447fad4eb0a9e3db287e1d16cce316114/docs/ECS0004.md)
 ECS0006 | Refactoring | Info | AvoidStringlyTypedApisAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers6213cba8473dac61d6132e205550884eae1c94bf/docs/ECS0006.md)
+ECS0007 | Design | Info | ExpressCallbacksWithDelegatesAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/dc194bbde030e9c40d8d9cdb1e0b5ff8919fe5a8/docs/ECS0007.md)
 ECS0009 | Performance | Info | MinimizeBoxingUnboxingAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/6213cba8473dac61d6132e205550884eae1c94bf/docs/ECS0009.md)
 ECS1000 | Performance | Info | SpanAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/d00a4cc9f61e7d5b392894aad859e46c43a5611c/docs/ECS1000.md)

--- a/src/EffectiveCSharp.Analyzers/DiagnosticIds.cs
+++ b/src/EffectiveCSharp.Analyzers/DiagnosticIds.cs
@@ -6,6 +6,7 @@ internal static class DiagnosticIds
     internal const string PreferReadonlyOverConst = "ECS0002";
     internal const string ReplaceStringFormatWithInterpolatedString = "ECS0004";
     internal const string AvoidStringlyTypedApis = "ECS0006";
+    internal const string ExpressCallbacksWithDelegates = "ECS0007";
     internal const string MinimizeBoxingUnboxing = "ECS0009";
     internal const string BeAwareOfValueTypeCopyInReferenceTypes = "ECS0009";
     internal const string UseSpanInstead = "ECS1000";

--- a/src/EffectiveCSharp.Analyzers/ExpressCallbacksWithDelegatesAnalyzer.cs
+++ b/src/EffectiveCSharp.Analyzers/ExpressCallbacksWithDelegatesAnalyzer.cs
@@ -52,15 +52,16 @@ public class ExpressCallbacksWithDelegatesAnalyzer : DiagnosticAnalyzer
         }
 
         // Check if the delegate is passed around or multicast
-        if (ShouldWarnForMethod(methodSymbol, invocationExpr, context.SemanticModel))
+        if (ShouldWarnForMethod(invocationExpr, context.SemanticModel))
         {
             Diagnostic diagnostic = invocationExpr.GetLocation().CreateDiagnostic(Rule, methodSymbol.Name);
             context.ReportDiagnostic(diagnostic);
         }
     }
 
-    private static bool ShouldWarnForMethod(IMethodSymbol methodSymbol, InvocationExpressionSyntax invocationExpr, SemanticModel semanticModel)
+    private static bool ShouldWarnForMethod(InvocationExpressionSyntax invocationExpr, SemanticModel semanticModel)
     {
+#pragma warning disable S3267 // Loops should be simplified with "LINQ" expressions
         foreach (ArgumentSyntax argument in invocationExpr.ArgumentList.Arguments)
         {
             ITypeSymbol? argumentType = semanticModel.GetTypeInfo(argument.Expression).Type;
@@ -83,6 +84,7 @@ public class ExpressCallbacksWithDelegatesAnalyzer : DiagnosticAnalyzer
                 // Additional checks for specific scenarios can be added here
             }
         }
+#pragma warning restore S3267 // Loops should be simplified with "LINQ" expressions
 
         // No issues detected
         return false;

--- a/src/EffectiveCSharp.Analyzers/ExpressCallbacksWithDelegatesAnalyzer.cs
+++ b/src/EffectiveCSharp.Analyzers/ExpressCallbacksWithDelegatesAnalyzer.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EffectiveCSharp.Analyzers;
+
+/// <summary>
+/// A <see cref="DiagnosticAnalyzer"/> for Effective C# Item #7 - Express callbacks with delegates.
+/// </summary>
+/// <seealso cref="Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer" />
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ExpressCallbacksWithDelegatesAnalyzer : DiagnosticAnalyzer
+{
+    private const string Id = DiagnosticIds.ExpressCallbacksWithDelegates;
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: Id,
+        title: "Express callbacks with delegates",
+        messageFormat: "Method '{0}' should use a delegate for the callback",
+        description: "Ensure that callbacks are implemented using delegates.",
+        category: "Design",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/{ThisAssembly.GitCommitId}/docs/{Id}.md");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+    {
+        var invocationExpr = (InvocationExpressionSyntax)context.Node;
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(invocationExpr, context.CancellationToken);
+        var methodSymbol = symbolInfo.Symbol as IMethodSymbol;
+
+        if (methodSymbol == null)
+            return;
+
+        // Check if the method has delegate parameters
+        bool hasDelegateParameter = methodSymbol.Parameters.Any(p => IsDelegateType(p.Type));
+        if (!hasDelegateParameter)
+        {
+            return;
+        }
+
+        var diagnostic = Diagnostic.Create(Rule, invocationExpr.GetLocation(), methodSymbol.Name);
+        context.ReportDiagnostic(diagnostic);
+    }
+
+    private static bool IsDelegateType(ITypeSymbol? typeSymbol)
+    {
+        if (typeSymbol == null)
+        {
+            return false;
+        }
+
+        if (typeSymbol.TypeKind == TypeKind.Delegate)
+        {
+            return true;
+        }
+
+        if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
+        {
+            // Handle Func<T>, Action<T>, Predicate<T>
+            if (namedTypeSymbol.ConstructedFrom != null &&
+                (namedTypeSymbol.ConstructedFrom.Name.StartsWith("Func") ||
+                 namedTypeSymbol.ConstructedFrom.Name.StartsWith("Action") ||
+                 namedTypeSymbol.ConstructedFrom.Name.StartsWith("Predicate")))
+            {
+                return true;
+            }
+
+            return namedTypeSymbol.ConstructedFrom.SpecialType == SpecialType.System_MulticastDelegate;
+        }
+
+        return false;
+    }
+}

--- a/src/EffectiveCSharp.Analyzers/SquiggleCop.Baseline.yaml
+++ b/src/EffectiveCSharp.Analyzers/SquiggleCop.Baseline.yaml
@@ -450,7 +450,7 @@
 - {Id: MA0029, Title: Combine LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0030, Title: Remove useless OrderBy call, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0031, Title: Optimize Enumerable.Count() usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: MA0032, Title: Use an overload with a CancellationToken argument, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0032, Title: Use an overload with a CancellationToken argument, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: MA0033, Title: Do not tag instance fields with ThreadStaticAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0035, Title: Do not use dangerous threading methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0036, Title: Make class static, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -1088,7 +1088,7 @@
 - {Id: S3263, Title: 'Static fields should appear in the order they must be initialized ', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S3264, Title: Events should be invoked, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S3265, Title: Non-flags enums should not be used in bitwise operations, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S3267, Title: Loops should be simplified with "LINQ" expressions, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3267, Title: Loops should be simplified with "LINQ" expressions, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
 - {Id: S3329, Title: Cipher Block Chaining IVs should be unpredictable, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S3330, Title: Creating cookies without the "HttpOnly" flag is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S3343, Title: Caller information parameters should come at the end of the parameter list, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}

--- a/src/EffectiveCSharp.Analyzers/SquiggleCop.Baseline.yaml
+++ b/src/EffectiveCSharp.Analyzers/SquiggleCop.Baseline.yaml
@@ -314,7 +314,7 @@
 - {Id: EM0105, Title: Duplicate Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: EnableGenerateDocumentationFile, Title: Set MSBuild property 'GenerateDocumentationFile' to 'true', Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: IDE0004, Title: Remove Unnecessary Cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0005_gen, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0007, Title: Use implicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0008, Title: Use explicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}

--- a/tests/EffectiveCSharp.Analyzers.Tests/ExpressCallbacksAsDelegateTests.cs
+++ b/tests/EffectiveCSharp.Analyzers.Tests/ExpressCallbacksAsDelegateTests.cs
@@ -149,7 +149,7 @@ public class ExpressCallbacksAsDelegateTests
                     collection.Add(2);
                     collection.Add(3);
             
-                    {|ECS0007:collection.ProcessItems(item => Console.WriteLine(item))|};
+                    collection.ProcessItems(item => Console.WriteLine(item));
                 }
             }
             """,
@@ -182,10 +182,10 @@ public class ExpressCallbacksAsDelegateTests
                 public void TestMethod()
                 {
                     var handler = new MultiDelegateHandler();
-                    {|ECS0007:handler.HandleItems(
+                    handler.HandleItems(
                         item => Console.WriteLine($"Processing item: {item}"),
                         item => item % 2 == 0
-                    )|};
+                    );
                 }
             }
             """,
@@ -216,10 +216,10 @@ public class ExpressCallbacksAsDelegateTests
                 public void TestMethod()
                 {
                     var processor = new TransformProcessor();
-                    {|ECS0007:processor.ProcessItems(
+                    processor.ProcessItems(
                         item => $"Item: {item}",
                         transformedItem => Console.WriteLine(transformedItem)
-                    )|};
+                    );
                 }
             }
             """,

--- a/tests/EffectiveCSharp.Analyzers.Tests/ExpressCallbacksAsDelegateTests.cs
+++ b/tests/EffectiveCSharp.Analyzers.Tests/ExpressCallbacksAsDelegateTests.cs
@@ -39,13 +39,12 @@ public class ExpressCallbacksAsDelegateTests
     [Fact]
     public async Task Delegate()
     {
+        // The problem here is that this works as a single delegate
+        // but when using it as a multicast delegate, things break.
+        // The value returned from invoking the delegate is the
+        // return value from the last function in the multicast chain.
+        // The return from the CheckWithUser() predicate is ignored.
         await Verifier.VerifyAnalyzerAsync(
-
-            // The problem here is that this works as a single delegate
-            // but when using it as a multicast delegate, things break.
-            // The value returned from invoking the delegate is the
-            // return value from the last function in the multicast chain.
-            // The return from the CheckWithUser() predicate is ignored.
             """
             public class MyClass
             {
@@ -81,12 +80,11 @@ public class ExpressCallbacksAsDelegateTests
     [Fact]
     public async Task CorrectDelegate()
     {
+        // You address both issues described in the Delegate test
+        // by invoking the delegate target yourself. Each delegate
+        // you create contains a list of delegates. You examine
+        // the chain yourself and call each one.
         await Verifier.VerifyAnalyzerAsync(
-
-            // You address both issues described in the Delegate test
-            // by invoking the delegate target yourself. Each delegate
-            // you create containst a list of delegates. You examine
-            // the chain yourself and call each one.
             """
             using System.Linq;
 
@@ -190,7 +188,7 @@ public class ExpressCallbacksAsDelegateTests
                     )|};
                 }
             }
-            """, 
+            """,
             ReferenceAssemblyCatalog.Latest);
     }
 

--- a/tests/EffectiveCSharp.Analyzers.Tests/ExpressCallbacksAsDelegateTests.cs
+++ b/tests/EffectiveCSharp.Analyzers.Tests/ExpressCallbacksAsDelegateTests.cs
@@ -1,0 +1,230 @@
+﻿using Verifier = EffectiveCSharp.Analyzers.Tests.Helpers.AnalyzerVerifier<EffectiveCSharp.Analyzers.ExpressCallbacksWithDelegatesAnalyzer>;
+
+namespace EffectiveCSharp.Analyzers.Tests;
+
+public class ExpressCallbacksAsDelegateTests
+{
+    [Fact]
+    public async Task Analyzer()
+    {
+        // The Find() method takes a delegate, in the form of
+        // Predicate<int>, to perform a test on each element
+        // of the list.
+        //
+        // TrueForAll() is similar
+        // RemoveAll() modifies the list container when the predicate is true
+        // ForEach() takes an Action<int> delegate
+        //
+        // The compiler converts the lambda expression into a method
+        // and creates a delegate to that method
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            public class MyClass
+            {
+              public void Test()
+              {
+                List<int> numbers = Enumerable.Range(1, 200).ToList();
+                var oddNumbers = numbers.Find(n=> n % 2 == 1);
+                var test = numbers.TrueForAll(n=> n < 50);
+            
+                numbers.RemoveAll(n => n % 2 == 0);
+            
+                numbers.ForEach(item => Console.WriteLine(item));
+              }
+            }
+            """,
+            ReferenceAssemblyCatalog.Latest);
+    }
+
+    [Fact]
+    public async Task Delegate()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+
+            // The problem here is that this works as a single delegate
+            // but when using it as a multicast delegate, things break.
+            // The value returned from invoking the delegate is the
+            // return value from the last function in the multicast chain.
+            // The return from the CheckWithUser() predicate is ignored.
+            """
+            public class MyClass
+            {
+              List<MyClass> container = new();
+            
+              public void LengthyOperation(Func<bool> predicate)
+              {
+                foreach(MyClass item in container)
+                {
+                    item.DoLengthyOperation();
+                    if (predicate() == false)
+                    {
+                        return;
+                    }
+                }
+              }
+              
+              public void DoLengthyOperation() {}
+              public bool CheckWithUser() => true;
+              public bool CheckWithSystem() => true;
+              
+              public void CheckThenDo()
+              {
+                Func<bool> cp = () => CheckWithUser();
+                cp += () => CheckWithSystem();
+                {|ECS0007:LengthyOperation(cp)|};
+              }
+            }
+            """,
+            ReferenceAssemblyCatalog.Latest);
+    }
+
+    [Fact]
+    public async Task CorrectDelegate()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+
+            // You address both issues described in the Delegate test
+            // by invoking the delegate target yourself. Each delegate
+            // you create containst a list of delegates. You examine
+            // the chain yourself and call each one.
+            """
+            using System.Linq;
+
+            public class MyClass
+            {
+              List<MyClass> container = new();
+            
+              public void LengthyOperation(Func<bool> predicate)
+              {
+                bool canContinue = true;
+                foreach(MyClass item in container)
+                {
+                  item.DoLengthyOperation();
+                  
+                  foreach(Func<bool> pr in predicate.GetInvocationList())
+                  {
+                    canContinue &= pr();
+                    
+                    if (!canContinue)
+                    {
+                      return;
+                    }
+                  }
+                }
+              }
+              
+              public void DoLengthyOperation() {}
+            }
+            """,
+            ReferenceAssemblyCatalog.Latest);
+    }
+
+    [Fact]
+    public async Task CustomCollectionWithCallback()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            public class CustomCollection<T>
+            {
+                private List<T> _items = new List<T>();
+            
+                public void Add(T item)
+                {
+                    _items.Add(item);
+                }
+            
+                public void ProcessItems(Action<T> callback)
+                {
+                    foreach (var item in _items)
+                    {
+                        callback(item);
+                    }
+                }
+            }
+            
+            public class TestClass
+            {
+                public void TestMethod()
+                {
+                    var collection = new CustomCollection<int>();
+                    collection.Add(1);
+                    collection.Add(2);
+                    collection.Add(3);
+            
+                    {|ECS0007:collection.ProcessItems(item => Console.WriteLine(item))|};
+                }
+            }
+            """,
+            ReferenceAssemblyCatalog.Latest);
+    }
+
+    [Fact]
+    public async Task MultiDelegateCallbackHandling()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            public class MultiDelegateHandler
+            {
+                private List<int> _items = new List<int> { 1, 2, 3, 4, 5 };
+            
+                public void HandleItems(Action<int> actionCallback, Predicate<int> predicateCallback)
+                {
+                    foreach (var item in _items)
+                    {
+                        if (predicateCallback(item))
+                        {
+                            actionCallback(item);
+                        }
+                    }
+                }
+            }
+
+            public class TestClass
+            {
+                public void TestMethod()
+                {
+                    var handler = new MultiDelegateHandler();
+                    {|ECS0007:handler.HandleItems(
+                        item => Console.WriteLine($"Processing item: {item}"),
+                        item => item % 2 == 0
+                    )|};
+                }
+            }
+            """, 
+            ReferenceAssemblyCatalog.Latest);
+    }
+
+    [Fact]
+    public async Task CallbackWithFunctionDelegate()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            public class TransformProcessor
+            {
+                private List<int> _items = new List<int> { 1, 2, 3, 4, 5 };
+            
+                public void ProcessItems(Func<int, string> transformCallback, Action<string> actionCallback)
+                {
+                    foreach (var item in _items)
+                    {
+                        var transformedItem = transformCallback(item);
+                        actionCallback(transformedItem);
+                    }
+                }
+            }
+
+            public class TestClass
+            {
+                public void TestMethod()
+                {
+                    var processor = new TransformProcessor();
+                    {|ECS0007:processor.ProcessItems(
+                        item => $"Item: {item}",
+                        transformedItem => Console.WriteLine(transformedItem)
+                    )|};
+                }
+            }
+            """,
+            ReferenceAssemblyCatalog.Latest);
+    }
+}

--- a/tests/EffectiveCSharp.Analyzers.Tests/Helpers/Test.cs
+++ b/tests/EffectiveCSharp.Analyzers.Tests/Helpers/Test.cs
@@ -19,6 +19,7 @@ internal class Test<TAnalyzer, TCodeFixProvider> : CSharpCodeFixTest<TAnalyzer, 
             """
             global using System;
             global using System.Collections.Generic;
+            global using System.Linq;
             """;
 
         TestState.Sources.Add(globalUsings);


### PR DESCRIPTION
Related: https://github.com/BillWagner/EffectiveCSharpAnalyzers/issues/7
Closes #32

The problem addressed by this rule is the use of methods that should involve callback mechanisms without employing delegates for this purpose. Specifically, methods are being invoked directly without the use of delegate types such as `Predicate<T>`, `Action<T>`, or `Func<T>`, which are designed to handle callbacks in a type-safe and consistent manner.

