### PR TITLE
Item #10 - Use the new modifier only to react to base class updates

### DIFF
--- a/src/EffectiveCSharp.Analyzers/Build/Config/General.globalconfig
+++ b/src/EffectiveCSharp.Analyzers/Build/Config/General.globalconfig
@@ -21,3 +21,10 @@ csharp_style_pattern_matching_over_as_with_null_check = true:warning
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_prefer_not_pattern = true:warning
 csharp_style_prefer_pattern_matching = true:warning
+
+# Title    : Use the new Modifier Only to React to Base Class Updates
+# Category : Style
+# Help Link: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1061
+#
+# Effective C# Item #10 - Use the new modifier only to react to base class Updates
+dotnet_diagnostic.CA1061.severity = warning


### PR DESCRIPTION
Resolves #35 

This is prohibited by CA1061. To implement this requirement, CA1061 is enabled as a warning