### PR TITLE
Correct false positive with ECS0009 on string.Concat on string + int

### DIFF
--- a/src/EffectiveCSharp.Analyzers/MinimizeBoxingUnboxingAnalyzer.cs
+++ b/src/EffectiveCSharp.Analyzers/MinimizeBoxingUnboxingAnalyzer.cs
@@ -34,12 +34,30 @@ public class MinimizeBoxingUnboxingAnalyzer : DiagnosticAnalyzer
             compilationStartAnalysisContext.RegisterOperationAction(AnalyzeOperation, OperationKind.Conversion);
             compilationStartAnalysisContext.RegisterSyntaxNodeAction(
                 syntaxNodeContext => AnalyzeNode(syntaxNodeContext, dictionarySymbol, listSymbol),
-                SyntaxKind.ElementAccessExpression);
+                SyntaxKind.ElementAccessExpression,
+                SyntaxKind.AddExpression);
         });
     }
 
     private static void AnalyzeNode(SyntaxNodeAnalysisContext context, INamedTypeSymbol? dictionarySymbol, INamedTypeSymbol? listSymbol)
     {
+        if (context.Node is BinaryExpressionSyntax binaryExpr
+            && binaryExpr.IsKind(SyntaxKind.AddExpression)
+            && context.SemanticModel.GetTypeInfo(binaryExpr.Left, context.CancellationToken).Type?.SpecialType == SpecialType.System_String)
+        {
+            // Check both sides for the addition of a string to something else
+            TypeInfo leftInfo = context.SemanticModel.GetTypeInfo(binaryExpr.Left, context.CancellationToken);
+            TypeInfo rightInfo = context.SemanticModel.GetTypeInfo(binaryExpr.Right, context.CancellationToken);
+
+            // If either side is a string and the other is a value type that is converted to string, it's safe
+            if ((leftInfo.Type?.SpecialType == SpecialType.System_String || rightInfo.Type?.SpecialType == SpecialType.System_String) &&
+                (leftInfo.Type?.IsValueType == true || rightInfo.Type?.IsValueType == true))
+            {
+                // Exclude string concatenation with value types that automatically call ToString
+                return;
+            }
+        }
+
         if (context.Node is not ElementAccessExpressionSyntax elementAccess)
         {
             return;
@@ -57,13 +75,13 @@ public class MinimizeBoxingUnboxingAnalyzer : DiagnosticAnalyzer
         if (SymbolEqualityComparer.Default.Equals(baseType, dictionarySymbol))
         {
             ITypeSymbol keyType = namedType.TypeArguments[0]; // The TKey in Dictionary<TKey, TValue>
-            if (ReportDiagnosticOnValueType(keyType))
+            if (ReportDiagnosticOnValueType(keyType, ref context, elementAccess))
             {
                 return;
             }
 
             ITypeSymbol valueType = namedType.TypeArguments[1]; // The TValue in Dictionary<TKey, TValue>
-            if (ReportDiagnosticOnValueType(valueType))
+            if (ReportDiagnosticOnValueType(valueType, ref context, elementAccess))
             {
                 return;
             }
@@ -71,7 +89,7 @@ public class MinimizeBoxingUnboxingAnalyzer : DiagnosticAnalyzer
         else if (SymbolEqualityComparer.Default.Equals(baseType, listSymbol))
         {
             ITypeSymbol elementType = namedType.TypeArguments[0]; // The T in List<T>
-            if (ReportDiagnosticOnValueType(elementType))
+            if (ReportDiagnosticOnValueType(elementType, ref context, elementAccess))
             {
                 return;
             }
@@ -80,23 +98,21 @@ public class MinimizeBoxingUnboxingAnalyzer : DiagnosticAnalyzer
         {
             Debug.Fail($"Unrecognized constructed from named type '{baseType}'.");
         }
+    }
 
-        return;
-
-        bool ReportDiagnosticOnValueType(ITypeSymbol? typeSymbol)
+    private static bool ReportDiagnosticOnValueType(ITypeSymbol? typeSymbol, ref SyntaxNodeAnalysisContext context, ElementAccessExpressionSyntax elementAccess)
+    {
+        // Check if the struct is read/write; if so, there can be bad things that happen to warn
+        if (typeSymbol is not { IsValueType: true, IsReadOnly: false })
         {
-            // Check if the struct is read/write; if so, there can be bad things that happen to warn
-            if (typeSymbol is not { IsValueType: true, IsReadOnly: false })
-            {
-                return false;
-            }
-
-            // Create and report a diagnostic if the element is accessed directly
-            Diagnostic diagnostic = elementAccess.GetLocation().CreateDiagnostic(Rule, typeSymbol.Name);
-            context.ReportDiagnostic(diagnostic);
-
-            return true;
+            return false;
         }
+
+        // Create and report a diagnostic if the element is accessed directly
+        Diagnostic diagnostic = elementAccess.GetLocation().CreateDiagnostic(Rule, typeSymbol.Name);
+        context.ReportDiagnostic(diagnostic);
+
+        return true;
     }
 
     private static void AnalyzeOperation(OperationAnalysisContext context)
@@ -113,10 +129,37 @@ public class MinimizeBoxingUnboxingAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeConversionOperation(IConversionOperation conversionOperation, OperationAnalysisContext context)
     {
-        if (conversionOperation.IsBoxingOrUnboxingOperation())
+        // We need to detect when a conversion operation should indeed considered to be problematic:
+        //
+        // 1. Excluding safe operations: Some conversions might be misidentified as boxing when they are safe or optimized
+        // away by the compiler, such as converting between numeric types or appending integers to strings which only involves
+        // calling `.ToString()`.
+        // 2. Context-Sensitive: Depending on the context of the conversion (like within a string concatenation), it might be
+        // considered boxing. Analyzing the parent operations or the usage context is needed to decide to trigger a boxing warning
+        // 3. Specific type checks: before reporting boxing, verify the types involved in the conversion are not special cases
+        // that are handled differently, like enum to string conversions in switch statements or using `int` in `string` concatentation
+
+        // Check if the conversion explicitly involves boxing or unboxing
+        if (!conversionOperation.IsBoxingOrUnboxingOperation())
         {
-            Diagnostic diagnostic = conversionOperation.Syntax.GetLocation().CreateDiagnostic(Rule);
-            context.ReportDiagnostic(diagnostic);
+            return;  // Skip conversions that do not involve boxing or unboxing
         }
+
+        // Further refinement: Check the usage context to avoid false positives
+        // Example: Avoid flagging string concatenations that do not actually box
+        if (conversionOperation.Parent is IBinaryOperation binaryOperation
+            && binaryOperation.OperatorKind == BinaryOperatorKind.Add
+            && binaryOperation.Type?.SpecialType == SpecialType.System_String)
+        {
+            ITypeSymbol? operandType = conversionOperation.Operand.Type;
+            if (operandType?.IsValueType == true && operandType.SpecialType != SpecialType.System_String)
+            {
+                // Typically, int + string triggers ToString() without boxing
+                return;
+            }
+        }
+
+        Diagnostic diagnostic = conversionOperation.Syntax.GetLocation().CreateDiagnostic(Rule);
+        context.ReportDiagnostic(diagnostic);
     }
 }


### PR DESCRIPTION
Fixes #45

```csharp
public class C {
  public void M() {
    var i = 0;
    var name = "Foo" + i;  // This is lowered to string name = string.Concat("Foo", i.ToString());
  }
}
```

Two additional checks added to the analyzer:

1. Analysis of the `SyntaxKind.AddExpression` and the `BinaryExpressionSyntax` to look for concat. This is more for defense in depth to stop additional special cased analysis that was there previously.
2. Update to `OperationKind.Conversion`.  When an `IConversionOperation` is analyzed, we need to consider a few things: there are safe operations where the compiler lowers the code to an optimal condition to avoid boxing, boxing depends on surrounding context, and last there are specific types that are special cased.