### PR TITLE
Update RunPerfTests.ps1 to enable roll-forward

### DIFF
--- a/build/scripts/perf/RunPerfTests.ps1
+++ b/build/scripts/perf/RunPerfTests.ps1
@@ -15,7 +15,7 @@ try {
         $projectFullPath = Join-Path $perftestRootFolder $project
         & dotnet restore $projectFullPath -verbosity detailed
         & dotnet build -c Release --no-incremental $projectFullPath
-        $comandArguments = "run -c Release --no-build --project $projectFullPath -- --warmupCount  2 --invocationCount 1 --runOncePerIteration --memory --exporters JSON --artifacts $output"
+        $comandArguments = "run -c Release --no-build --roll-forward Major --project $projectFullPath -- --warmupCount  2 --invocationCount 1 --runOncePerIteration --memory --exporters JSON --artifacts $output"
         if ($ci) {
             $comandArguments = "$comandArguments --stopOnFirstError --keepFiles"
         }


### PR DESCRIPTION
Enhanced performance testing flexibility by allowing the .NET runtime to select compatible framework versions with the addition of the `--roll-forward Major` option.
 
Fixes #64 