### PR TITLE
Move unshipped rules docs to shipped and update performance baseline commitid

### DIFF
--- a/build/perf/baseline.json
+++ b/build/perf/baseline.json
@@ -1,5 +1,5 @@
 {
     "release": "0.1.0",
     "label": "v0.1.0",
-    "sha": "75e6c1b724be72db803fef4ebc99f07bdee4bf61"
+    "sha": "9144e7c2240d02021734e67795adc2f4096d15ce"
   }

--- a/src/EffectiveCSharp.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/EffectiveCSharp.Analyzers/AnalyzerReleases.Shipped.md
@@ -14,3 +14,12 @@ ECS0600 | Refactoring | Info | AvoidStringlyTypedApisAnalyzer, [Documentation](h
 ECS0700 | Design | Info | ExpressCallbacksWithDelegatesAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/c0c5d965e88f59c3acbd867a74b55eed052df5b1/docs/rules/ECS0007.md)
 ECS0800 | Usage | Info | EventInvocationAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/c0c5d965e88f59c3acbd867a74b55eed052df5b1/docs/rules/ECS0008.md)
 ECS0900 | Performance | Info | MinimizeBoxingUnboxingAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/c0c5d965e88f59c3acbd867a74b55eed052df5b1/docs/rules/ECS0009.md)
+
+## Release 0.2.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+ECS1200 | Maintainability | Info | PreferMemberInitializerAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/75e6c1b724be72db803fef4ebc99f07bdee4bf61/docs/rules/ECS1200.md)
+ECS1300 | Initialization | Info | StaticClassMemberInitializationAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/9144e7c2240d02021734e67795adc2f4096d15ce/docs/rules/ECS1300.md)

--- a/src/EffectiveCSharp.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/EffectiveCSharp.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,5 +5,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-ECS1200 | Maintainability | Info | PreferMemberInitializerAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/97c51a41b53d059cfcd06f0c8ce5ab178b070e6b/docs/rules/ECS1200.md)
-ECS1300 | Initialization | Info | StaticClassMemberInitializationAnalyzer, [Documentation](https://github.com/rjmurillo/EffectiveCSharp.Analyzers/blob/ce4060555cece9d43160bfbef91e30dab9f0178b/docs/rules/ECS1300.md)


### PR DESCRIPTION
## Changes

- Moved analyzer rule documentation from "unshipped" to "shipped" for 0.2.0
  - **ECS1200** - "PreferMemberInitializerAnalyzer" for maintainability.
  - **ECS1300** - "StaticClassMemberInitializationAnalyzer" for initialization.
- Updated the SHA identifier in the performance baseline file.