### PR TITLE
Move support to sdk 8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,14 +12,17 @@
       These items impact our compatibility with SDK versions, so follow
       to strike a balance between compatibility and modernity.
 
-      These are the two main documents to reference how the Public API impacts users:
-      - https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md
+      These are the three main documents to reference how the Public API impacts users:
+      - https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md?plain=1
+      - https://learn.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs#lifecycle
       - https://learn.microsoft.com/en-us/visualstudio/productinfo/vs-servicing
     -->
-    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
+    <!-- We are using 4.8, which introduces .NET 8 and supports VS 2022 17.8 -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8" />
   </ItemGroup>
   <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.12" />
     <PackageVersion Include="GetPackFromProject" Version="1.0.6" />

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.100",
-    "rollForward": "disable" /* setup-dotnet is broken and we don't want to have differences in CI vs local, so make this disabled */
+    "rollForward": "patch" /* setup-dotnet is broken and we don't want to have differences in CI vs local, so make this disabled */
   },
   "msbuild-sdks": {
     "DotNet.ReproducibleBuilds.Isolated": "1.2.4"

--- a/src/tools/PerfDiff/PerfDiff.csproj
+++ b/src/tools/PerfDiff/PerfDiff.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <NonShipping>true</NonShipping>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>

--- a/tests/EffectiveCSharp.Analyzers.Benchmarks/Helpers/BenchmarkCSharpCompilationFactory.cs
+++ b/tests/EffectiveCSharp.Analyzers.Benchmarks/Helpers/BenchmarkCSharpCompilationFactory.cs
@@ -16,8 +16,8 @@ internal static class BenchmarkCSharpCompilationFactory
             throw new InvalidOperationException("Failed to create compilation");
         }
 
-        CompilationWithAnalyzers baseline = compilation.WithAnalyzers([new EmptyDiagnosticAnalyzer()], options, CancellationToken.None);
-        CompilationWithAnalyzers test = compilation.WithAnalyzers([new TAnalyzer()], options, CancellationToken.None);
+        CompilationWithAnalyzers baseline = compilation.WithAnalyzers([new EmptyDiagnosticAnalyzer()], options);
+        CompilationWithAnalyzers test = compilation.WithAnalyzers([new TAnalyzer()], options);
 
         return (baseline, test);
     }
@@ -35,9 +35,9 @@ internal static class BenchmarkCSharpCompilationFactory
             throw new InvalidOperationException("Failed to create compilation");
         }
 
-        CompilationWithAnalyzers baseline = compilation.WithAnalyzers([new EmptyDiagnosticAnalyzer()], options, CancellationToken.None);
-        CompilationWithAnalyzers test1 = compilation.WithAnalyzers([new TAnalyzer1()], options, CancellationToken.None);
-        CompilationWithAnalyzers test2 = compilation.WithAnalyzers([new TAnalyzer2()], options, CancellationToken.None);
+        CompilationWithAnalyzers baseline = compilation.WithAnalyzers([new EmptyDiagnosticAnalyzer()], options);
+        CompilationWithAnalyzers test1 = compilation.WithAnalyzers([new TAnalyzer1()], options);
+        CompilationWithAnalyzers test2 = compilation.WithAnalyzers([new TAnalyzer2()], options);
 
         return (baseline, test1, test2);
     }


### PR DESCRIPTION
This change moves the minimum supported SDK to 8.0.100, the SDK that shipped with Visual Studio 2022 version 17.8 and C# 12.0. This is the earliest SDK that is in support.

- **New Features**
	- Updated package versions to support .NET 8 and Visual Studio 2022.
	- Added new documentation references for SDK versioning.

- **Bug Fixes**
	- Adjusted roll-forward policy for .NET SDK versioning to allow patch-level updates.

- **Refactor**
	- Streamlined method calls by removing unnecessary cancellation token arguments in benchmark compilation factory.

- **Chores**
	- Updated target framework from .NET 8.0 to .NET 9.0 in the `PerfDiff` project file.

